### PR TITLE
Scale heart icon with factor 1.25

### DIFF
--- a/src/app/songs/songs.component.scss
+++ b/src/app/songs/songs.component.scss
@@ -36,7 +36,7 @@
   background-color: transparent;
   box-shadow: none;
   filter: $drop-shadow;
-  transform: scale(1.2);
+  transform: scale(1.25);
 }
 
 


### PR DESCRIPTION
1.2 results in a px value with decimal places which causes weird jitter when clicking the icon.
1.25 results in exactly 30.00px and I don't see any jitter when clicking.
Since 1.2 is not much different from 1.25, I think we should revert back to 1.25.