### PR TITLE
Prevent text overlap with input clear icon

### DIFF
--- a/src/app/search/search.component.scss
+++ b/src/app/search/search.component.scss
@@ -7,6 +7,7 @@
 
 input {
   width: 100%;
+  padding: 0 dp(56) 0 dp(16);
 }
 
 .clear {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -41,7 +41,6 @@ body {
 
 .input {
   height: dp(56);
-  padding: 0 dp(16);
   font-size: dp(18);
   transition: 0.15s ease-out;
   border: 2px solid $text-color;


### PR DESCRIPTION
Increases `padding-right` to `56dp` which is the width of the clear button.

![2018-09-03 03_02_35-shareme](https://user-images.githubusercontent.com/6810177/44962841-df4fcd80-af25-11e8-8fc5-bddadfe138e6.png)
