### PR TITLE
Limit results to 30

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -27,6 +27,7 @@ export class SearchComponent implements AfterViewInit {
   readonly suggestionChanges = this.input.valueChanges.pipe(
     debounceTime(100),
     map(this.suggestionsService.getSuggestions),
+    map(results => results.slice(0, 30)),
     shareReplay(),
   )
 


### PR DESCRIPTION
Suggestion list is sluggish on slow mobile devices when multiple hundred results are shown.